### PR TITLE
feat: set npm publishing to manual fixes #56

### DIFF
--- a/.github/workflows/npm-module-release.yml
+++ b/.github/workflows/npm-module-release.yml
@@ -1,27 +1,8 @@
-on: [push, pull_request]
-name: Build and Publish
+name: Publish NPM Package
+on:
+  workflow_dispatch:
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js '16.x'
-      uses: actions/setup-node@v1
-      with:
-        node-version: '16.x'
-    - name: Cache node_modules
-      id: cache-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: 16.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
-    - name: Build
-      if: steps.cache-modules.outputs.cache-hit != 'true'
-      run: npm install
   publish:
-    if: github.event_name == 'push' && ( github.ref == 'refs/heads/main' )
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
- Set NPM Publishing to Manual.
- Removed Build from this workflow, because we will run Publish, when we will have a successful build and release.
- Cleaned the Workflow


Fixes #56 
