### PR TITLE
#64: Pack the library in PRs and Pushes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,6 +40,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Webpack Prod Bundle
+        run: npm run pre-publish
+        working-directory: ${{ env.project-directory }}
+
       - name: get-npm-version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@master

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,10 +40,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Webpack Prod Bundle
-        run: npm run pre-publish
-        working-directory: ${{ env.project-directory }}
-
       - name: get-npm-version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@master

--- a/.github/workflows/npm-module-release.yml
+++ b/.github/workflows/npm-module-release.yml
@@ -10,6 +10,9 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+      - name: Webpack Prod Bundle
+        run: npm run pre-publish
+        working-directory: ${{ env.project-directory }}
       - name: Publish
         run: |
           npm config set '//registry.npmjs.org/:_authToken' "${{secrets.NPM_AUTH_TOKEN}}"

--- a/.github/workflows/npm-module-release.yml
+++ b/.github/workflows/npm-module-release.yml
@@ -10,9 +10,6 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Webpack Prod Bundle
-        run: npm run pre-publish
-        working-directory: ${{ env.project-directory }}
       - name: Publish
         run: |
           npm config set '//registry.npmjs.org/:_authToken' "${{secrets.NPM_AUTH_TOKEN}}"

--- a/.github/workflows/npm-module-release.yml
+++ b/.github/workflows/npm-module-release.yml
@@ -13,8 +13,9 @@ jobs:
       - name: Publish
         run: |
           npm config set '//registry.npmjs.org/:_authToken' "${{secrets.NPM_AUTH_TOKEN}}"
-          npm install -D husky
+          npm install -D husky webpack
           npx husky install
+          npx webpack --mode=production
           npm publish --ignore-scripts
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
#64 

Added `npm run pre-publish` step to `build-release` GitHub action.

Result of running action on my fork: https://github.com/kparikh9/treetracker-web-map-core/actions/runs/1776541279.