### PR TITLE
Draft Pull Request - Web Map Core Issue #48: Expose an Option of the Map: Zoom in/out button

### DIFF
--- a/issuefix
+++ b/issuefix
@@ -1,0 +1,9 @@
+Web Map Core Issue # 48: Expose an Option of the Map: zoom in/out button
+
+Description
+
+Summary of Change - Issue Fixed - Relevant Motivation & Context
+
+Fixes
+
+Type of Change


### PR DESCRIPTION
Description of Issue and Fix
This pull request was created to assist in the following issue on the web map core section. Issue #48 Expose an Option of the Map: Zoom in/out button. https://github.com/Greenstand/treetracker-web-map-core/issues/48. 
It offers a possible solution on what can be done to improve the situation. The zoom in/out button for the treetracker web map is situated at the bottom right corner, the zoom feature needs to be exposed as an option of the map. The reason for this issue is that for the zoom feature, the element will fade out when being used by users. 

Code 
This code can be configured to the web map repository so that it may allow the zoom feature to be exposed. There are two different calls used which are the expose and mask feature. The expose method takes all elements (returned by selector) and any jQuery selectors and are placed on top of the mask. The mask is loaded right after the expose/mask call. Furthermore, an existing element can be used as a mask. This code snippet was taken from the following website: https://jquerytools.github.io/documentation/toolbox/expose.html. 

// place a white mask over page
$(document).mask();
 
// places the custom colored mask over page
$(document).mask("#789");
 
// place non-closable mask (on zoom element)
$(document).mask{ closeOnEsc: false, closeOnClick: false });
 
// places the mask but let selected zoom element show through (be exposed)
$("div.to_be_exposed").expose();
 
// closes the mask
$.mask.close();

