### PR TITLE
Feat/ Add arrows to show nearest trees and move to nearest feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treetracker-web-map-core",
-  "version": "1.4.1",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "treetracker-web-map-core",
-      "version": "1.4.1",
+      "version": "1.7.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.24.0",

--- a/src/NearestTreeArrows.js
+++ b/src/NearestTreeArrows.js
@@ -1,0 +1,41 @@
+import './style.css'
+
+export default class NearestTreeArrows {
+  constructor(moveToNearest) {
+    this.moveToNearest = moveToNearest
+  }
+
+  mount(element) {
+    this.arrow = document.createElement('div')
+    this.arrow.innerHTML = `
+    <div class="round">
+      <div id="cta">
+        <span class="arrow primera next "></span>
+        <span class="arrow segunda next "></span>
+      </div>
+    </div>
+    `
+    this.arrow.id = 'arrow'
+    element.appendChild(this.arrow)
+
+    this.arrow.addEventListener('click', this.arrowClickHandler.bind(this))
+
+    this.arrow.style.display = 'none'
+  }
+
+  hideArrow() {
+    this.arrow.className = ''
+    this.arrow.style.display = 'none'
+  }
+
+  showArrow(direction) {
+    this.arrow.className = ''
+    this.arrow.style.display = 'block'
+    this.arrow.className = `${direction}`
+  }
+
+  arrowClickHandler() {
+    this.hideArrow()
+    this.moveToNearest()
+  }
+}

--- a/src/NearestTreeArrows.js
+++ b/src/NearestTreeArrows.js
@@ -31,7 +31,16 @@ export default class NearestTreeArrows {
   showArrow(direction) {
     this.arrow.className = ''
     this.arrow.style.display = 'block'
-    this.arrow.className = `${direction}`
+
+    // Check if the prev & next tree button panel exists, if it does shift the nearest NORTH arrow to the right
+    const buttonPanelExists =
+      document.getElementById('greenstand-map-buttonPanel').firstChild.style
+        .display !== 'none'
+    this.arrow.className = `${
+      buttonPanelExists && direction === 'north'
+        ? direction + ' shift'
+        : direction
+    }`
   }
 
   arrowClickHandler() {

--- a/src/style.css
+++ b/src/style.css
@@ -279,21 +279,24 @@
 
 #arrow.south {
   bottom: 10px;
-  left: 50%;
+  left: 47%;
 }
 
 #arrow.north {
-  top: 20px;
+  top: 10px;
+  left: 47%;
+}
+#arrow.north.shift {
   left: 75%;
 }
 
 #arrow.east {
-  top: 50%;
+  top: 46%;
   right: 10px;
 }
 
 #arrow.west {
-  top: 50%;
+  top: 46%;
   left: 10px;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -268,3 +268,129 @@
   font-size: 12px;
   font-weight: 500;
 }
+
+/* Nearest Tree Arrows */
+#arrow {
+  position: absolute;
+  display: block;
+  cursor: pointer;
+  z-index: 99999 !important;
+}
+
+#arrow.south {
+  bottom: 10px;
+  left: 50%;
+}
+
+#arrow.north {
+  top: 20px;
+  left: 75%;
+}
+
+#arrow.east {
+  top: 50%;
+  right: 10px;
+}
+
+#arrow.west {
+  top: 50%;
+  left: 10px;
+}
+
+.round {
+  border: 0px solid #fff;
+  width: 40px;
+  height: 40px;
+  border-radius: 100%;
+}
+
+.south .round {
+  transform: rotate(90deg) scale(2);
+}
+
+.north .round {
+  transform: rotate(270deg) scale(2);
+  top: 10px;
+}
+
+.west .round {
+  transform: rotate(180deg) scale(2);
+  left: 10px;
+}
+
+.east .round {
+  transform: rotate(0deg) scale(2);
+  right: 10px;
+}
+
+#cta {
+  width: 100%;
+  position: absolute;
+}
+
+#cta .arrow {
+  left: 30%;
+}
+.arrow {
+  position: absolute;
+  bottom: 0;
+  margin-left: 0px;
+  width: 12px;
+  height: 12px;
+  background-size: contain;
+  top: 15px;
+}
+.segunda {
+  margin-left: 8px;
+}
+.next {
+  background-image: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiI+PHN0eWxlPi5zdDB7ZmlsbDojZmZmfTwvc3R5bGU+PHBhdGggY2xhc3M9InN0MCIgZD0iTTMxOS4xIDIxN2MyMC4yIDIwLjIgMTkuOSA1My4yLS42IDczLjdzLTUzLjUgMjAuOC03My43LjZsLTE5MC0xOTBjLTIwLjEtMjAuMi0xOS44LTUzLjIuNy03My43UzEwOSA2LjggMTI5LjEgMjdsMTkwIDE5MHoiLz48cGF0aCBjbGFzcz0ic3QwIiBkPSJNMzE5LjEgMjkwLjVjMjAuMi0yMC4yIDE5LjktNTMuMi0uNi03My43cy01My41LTIwLjgtNzMuNy0uNmwtMTkwIDE5MGMtMjAuMiAyMC4yLTE5LjkgNTMuMi42IDczLjdzNTMuNSAyMC44IDczLjcuNmwxOTAtMTkweiIvPjwvc3ZnPg==);
+}
+
+@keyframes bounceAlpha {
+  0% {
+    opacity: 1;
+    transform: translateX(0px) scale(1);
+  }
+  25% {
+    opacity: 0;
+    transform: translateX(10px) scale(0.9);
+  }
+  26% {
+    opacity: 0;
+    transform: translateX(-10px) scale(0.9);
+  }
+  55% {
+    opacity: 1;
+    transform: translateX(0px) scale(1);
+  }
+}
+
+.bounceAlpha {
+  animation-name: bounceAlpha;
+  animation-duration: 1.4s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+
+.arrow.primera.bounceAlpha {
+  animation-name: bounceAlpha;
+  animation-duration: 1.4s;
+  animation-delay: 0.2s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+
+.round .arrow {
+  animation-name: bounceAlpha;
+  animation-duration: 1.4s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+.round .arrow.primera {
+  animation-name: bounceAlpha;
+  animation-duration: 1.4s;
+  animation-delay: 0.2s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}


### PR DESCRIPTION
### Summary

- Migrated the `nearest` tree feature from web-map-client so that the Web-map-core displays the nearest arrows and handles the arrow click events to move to the nearest trees. 
- The map will now check for the markers every time the map is panned and display the nearest arrows if it doesn't detect any tree markers in the view. This fixes the bug that was causing the arrows not being displayed in map-client.
- A new `NearestTreeArrows` class was added for the arrows and styling code for the arrows were migrated from map-client. 
- The north arrow button will dynamically change the position depending on the next/prev `buttonPanel` #79 


closes #30 

https://user-images.githubusercontent.com/52301822/156684091-8b7e0d14-f127-4f23-a4ca-de1ba262f065.mp4


