### PR TITLE
fix: getbounds from filter obj

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -880,6 +880,9 @@ export default class Map {
     if (this.filters.map_name) {
       filters.map_name = this.filters.map_name
     }
+    if (this.filters.bounds) {
+      filters.bounds = this.filters.bounds
+    }
     return filters
   }
 


### PR DESCRIPTION
inorder to fix (https://github.com/Greenstand/treetracker-web-map-client/issues/754) get filter method has to return bounds as a key-pair value too,as we can see  this code suggests that we need to pass bounds as query param too which we aren`t currently doing 