### PR TITLE
feat: improve next/previous buttons

### DIFF
--- a/src/ButtonPanel.js
+++ b/src/ButtonPanel.js
@@ -1,6 +1,8 @@
 /* The ButtonPanel component */
 import './style.css'
 import log from 'loglevel'
+import leftArrowComponent from './images/left-arrow.svg'
+import rightArrowComponent from './images/right-arrow.svg'
 
 export default class ButtonPanel {
   constructor(onNext, onPrev) {
@@ -45,26 +47,8 @@ export default class ButtonPanel {
     this.leftArrow = document.createElement('span')
     this.rightArrow = document.createElement('span')
 
-    this.leftArrow.innerHTML = `
-    <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-        viewBox="0 -100 477.175 677.175" style="enable-background:new 0 -100 477.175 677.175;" xml:space="preserve">
-    <g>
-      <path d="M145.188,238.575l215.5-215.5c5.3-5.3,5.3-13.8,0-19.1s-13.8-5.3-19.1,0l-225.1,225.1c-5.3,5.3-5.3,13.8,0,19.1l225.1,225
-        c2.6,2.6,6.1,4,9.5,4s6.9-1.3,9.5-4c5.3-5.3,5.3-13.8,0-19.1L145.188,238.575z" fill="#ffffff"/>
-    </g>
-    </svg>
-    `
-
-    this.rightArrow.innerHTML = `
-    <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-        viewBox="0 -100 477.175 677.175" style="enable-background:new 0 -100 477.175 677.175;" xml:space="preserve">
-    <g>
-      <path d="M360.731,229.075l-225.1-225.1c-5.3-5.3-13.8-5.3-19.1,0s-5.3,13.8,0,19.1l215.5,215.5l-215.5,215.5
-        c-5.3,5.3-5.3,13.8,0,19.1c2.6,2.6,6.1,4,9.5,4c3.4,0,6.9-1.3,9.5-4l225.1-225.1C365.931,242.875,365.931,234.275,360.731,229.075z
-        " fill="#ffffff"/>
-    </g>
-    </svg>
-    `
+    this.leftArrow.innerHTML = `<img src="${leftArrowComponent}" height="60px" width="60px" />`
+    this.rightArrow.innerHTML = `<img src="${rightArrowComponent}" height="60px" width="60px" />`
 
     this.leftArrow.className = 'next-button-arrow'
     this.rightArrow.className = 'next-button-arrow'

--- a/src/Map.js
+++ b/src/Map.js
@@ -154,7 +154,7 @@ export default class Map {
       <div id="greenstand-leaflet" style="position: relative;width: 100%;height: 100%;"></div>
       <div id="greenstand-map-spin" style="z-index: 999; position: absolute; width: 100%; top: 0px; left: 0px" ></div>
       <div id="greenstand-map-alert" style="z-index: 999; position: absolute; width: 100%; top: 0px; left: 0px" ></div>
-      <div id="greenstand-map-buttonPanel" style="z-index: 999; position: absolute; top: 0px; left:50%; transform: translateX(-50%)" ></div>
+      <div id="greenstand-map-buttonPanel" style="z-index: 999; position: absolute; top: 24px; left:50%; transform: translateX(-50%)" ></div>
     `
     domElement.appendChild(divContainer)
     const mountTarget = document.getElementById('greenstand-leaflet')

--- a/src/images/left-arrow.svg
+++ b/src/images/left-arrow.svg
@@ -1,0 +1,14 @@
+<svg width="24" height="32" viewBox="0 0 24 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_b_9818_1422)">
+<rect width="24" height="32" rx="8" fill="#222629" fill-opacity="0.6"/>
+<path d="M15.6883 8.35754C15.2727 7.88082 14.6234 7.88082 14.2078 8.35754L8.31169 15.1508C7.8961 15.6276 7.8961 16.3724 8.31169 16.8492L14.2338 23.6425C14.4416 23.8808 14.7013 24 14.961 24C15.2208 24 15.4805 23.8808 15.6883 23.6425C16.1039 23.1657 16.1039 22.4209 15.6883 21.9441L10.5195 15.9851L15.6883 10.0559C16.1039 9.57914 16.1039 8.83426 15.6883 8.35754Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_b_9818_1422" x="-25" y="-25" width="74" height="82" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feGaussianBlur in="BackgroundImage" stdDeviation="12.5"/>
+<feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur_9818_1422"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur_9818_1422" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/images/right-arrow.svg
+++ b/src/images/right-arrow.svg
@@ -1,0 +1,14 @@
+<svg width="24" height="32" viewBox="0 0 24 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_b_9818_1420)">
+<rect x="24" y="32" width="24" height="32" rx="8" transform="rotate(-180 24 32)" fill="#222629" fill-opacity="0.6"/>
+<path d="M8.31169 23.6425C8.72727 24.1192 9.37662 24.1192 9.79221 23.6425L15.6883 16.8492C16.1039 16.3724 16.1039 15.6276 15.6883 15.1508L9.76623 8.35754C9.55844 8.11918 9.2987 8 9.03896 8C8.77922 8 8.51948 8.11918 8.31169 8.35754C7.8961 8.83427 7.8961 9.57914 8.31169 10.0559L13.4805 16.0149L8.31169 21.9441C7.8961 22.4209 7.8961 23.1657 8.31169 23.6425Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_b_9818_1420" x="-25" y="-25" width="74" height="82" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feGaussianBlur in="BackgroundImage" stdDeviation="12.5"/>
+<feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur_9818_1420"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur_9818_1420" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/style.css
+++ b/src/style.css
@@ -141,21 +141,18 @@
 }
 
 .buttonPanel {
-  width: 140px;
-  height: 90px;
+  width: 144px;
+  display: flex;
+  justify-content: space-between;
 }
 #next-left-arrow,
 #next-right-arrow {
-  margin: 5px;
-  flex: 40%;
-  height: 90px;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 #next-left-arrow svg,
 #next-right-arrow svg {
-  height: 70px;
   background: rgba(0, 0, 0, 0.4);
   border-radius: 15%;
 }


### PR DESCRIPTION
# Description

Add new icons
Change button sizes conform ux best practices, see the link below

Button tap/click space is now 60x60

UX for mobile buttons: https://uxmovement.com/mobile/optimal-size-and-spacing-for-mobile-buttons/

## Screenshots
Before|After
:-:|:-:
![localhost_5000_ (1)](https://user-images.githubusercontent.com/31519867/188843209-be9f4315-1dc4-46ce-be7e-c658a1e51082.png)|![localhost_5000_](https://user-images.githubusercontent.com/31519867/188843243-83dc3bd5-755c-4ead-8825-dc4116973953.png)

