### PR TITLE
refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treetracker-web-map-core",
-  "version": "1.13.0",
+  "version": "2.1.8",
   "description": "This is the core module for Greenstand web map application.",
   "keywords": [
     "GIS",

--- a/src/Map.js
+++ b/src/Map.js
@@ -903,7 +903,9 @@ export default class Map {
     // mount event
     this.map.on('moveend', (e) => {
       log.warn('move end', e)
-      this._checkArrow()
+      if (this._isNeededToCheckArrow()) {
+        this._checkArrow()
+      }
       this.events.emit(Map.REGISTERED_EVENTS.MOVE_END)
     })
 
@@ -1082,6 +1084,15 @@ export default class Map {
     this.map.panTo(location)
   }
 
+  _isNeededToCheckArrow() {
+    if (this.filters.treeid || this.filters.tree_name) {
+      log.info('treeid mode do not need to check arrow')
+      return false
+    } else {
+      return true
+    }
+  }
+
   _flyTo(lat, lon, zoomLevel) {
     log.info('fly to:', lat, lon, zoomLevel)
     this.map.gotoView(lat, lon, zoomLevel)
@@ -1142,7 +1153,7 @@ export default class Map {
       log.warn('res:', res)
       if (!res) {
         log.error("Can't find tree by url:", url)
-        throw new MapError('Can not find any data')
+        throw new MapError('Can not find any data!')
       }
       const { lat, lon } = res
       view = {

--- a/src/Map.js
+++ b/src/Map.js
@@ -1309,10 +1309,14 @@ export default class Map {
    * reset the config of map instance
    */
   async setFilters(filters) {
-    this.filters = filters
-    await this._unselectMarker()
-    await this._unloadTileServer()
-    await this._loadTileServer()
+    if (_.isEqual(filters, this.filters)) {
+      log.warn('filters is not changed, do nothing')
+    } else {
+      this.filters = filters
+      await this._unselectMarker()
+      await this._unloadTileServer()
+      await this._loadTileServer()
+    }
   }
 
   clearSelection() {

--- a/src/Map.js
+++ b/src/Map.js
@@ -50,7 +50,7 @@ export default class Map {
         height: window.innerHeight,
         debug: false,
         moreEffect: true,
-        filters: {},
+        filters: null,
         defaultZoomLevelForTreePoint: 15,
       },
       ...options,
@@ -1189,6 +1189,13 @@ export default class Map {
     }
   }
 
+  getCurrentView() {
+    return {
+      center: this.map.getCenter(),
+      zoomLevel: this.map.getZoom(),
+    }
+  }
+
   async gotoBounds(bounds) {
     const [southWestLng, southWestLat, northEastLng, northEastLat] =
       bounds.split(',')
@@ -1309,6 +1316,7 @@ export default class Map {
    * reset the config of map instance
    */
   async setFilters(filters) {
+    log.warn('new, old filter:', filters, this.filters)
     if (_.isEqual(filters, this.filters)) {
       log.warn('filters is not changed, do nothing')
     } else {


### PR DESCRIPTION
- feat: change to private methods for map.js
- chore: loadTileServer fn
- feat: split to get view and goto view fns
- feat: setFilter will refresh the layers
- chore: can demo open planter map, goto tree, select tree
- feat: refactor gotoView
- feat: new api BREAKING CHANGE: new api
- feat: do not render map by default when mounting
- fix: shouldn't trigger click when load single tree
- chore: do not check arrow in some case
- chore: do not reload if fitler is the same
- chore: get currentview
- feat: issues fixed
