### PR TITLE
fix: the nearest arrow keep showing 70 treetracker-we-map-client

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -284,6 +284,7 @@ export default class Map {
           log.warn('load finished')
           this.spin.hide()
           this.alert.hide()
+          this._checkArrow()
         },
         onDestroy: () => {
           log.warn('destroy')
@@ -324,7 +325,6 @@ export default class Map {
 
       this.layerUtfGrid.on('load', () => {
         log.info('all grid loaded!')
-        this._checkArrow()
       })
 
       this.layerUtfGrid.on('tileunload', (e) => {
@@ -352,13 +352,6 @@ export default class Map {
 
       // bind the finding marker function
       this.layerUtfGrid.hasMarkerInCurrentView = () => {
-        // waiting layer is ready
-        const isLoading = this.layerUtfGrid.isLoading()
-        log.warn('utf layer is loading:', isLoading)
-        if (isLoading) {
-          log.warn('can not handle the grid utf check when loading, cancel!')
-          return false
-        }
         const begin = Date.now()
         let found = false
         let count = 0
@@ -960,6 +953,7 @@ export default class Map {
     log.info('check arrow...')
     if (this.layerUtfGrid.hasMarkerInCurrentView()) {
       log.info('found marker')
+      this.nearestTreeArrow.hideArrow()
     } else {
       log.info('no marker')
       const nearest = await this._getNearest()


### PR DESCRIPTION
The problem with the arrow is due to the fact that the Marker grid did not load, but a check for its presence is already underway, and the function goes to building the arrow. 
Even if we run the check again afterwards, the arrow may load later due to asynchrony _getNearest .
Also, the hasMarkerInCurrentView function doesn't live up to its name, because it returned a missing markers result even when it didn't check for it. (because of isLoading)
