### PR TITLE
Chore: Add Types To ButtonPanel Component

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,6 @@
 node_modules/
 dist/
 coverage/
-mapTools.cy.js
+mapTools.cy.
+
+

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ _check `dist/index.html` for a demo_
 [npm-image]: https://img.shields.io/npm/v/treetracker-web-map-core.svg
 [npm-url]: https://npmjs.org/package/treetracker-web-map-core
 
-
 # how to debug the core on the client side
 
 The senerio: sometime we need to find a easy way to debug the core in the client side, for example, the web map client repo, it's installing the core by npm, so it's hard to change code in core on the client side, we can install the core by `folder` locally, and get the change on the client side immediately, to do so:

--- a/src/ButtonPanel.ts
+++ b/src/ButtonPanel.ts
@@ -13,22 +13,20 @@ export default class ButtonPanel implements ButtonPanelMethods {
   buttonPanel: HTMLDivElement
   leftArrow: HTMLDivElement
   rightArrow: HTMLDivElement
-  constructor(
-    public onNext: () => void,
-    public onPrev: () => void,
-    public isHidden: boolean = false,
-  ) {
+  private _isHidden: Boolean
+
+  constructor(public onNext: () => void, public onPrev: () => void) {
     this.onNext = onNext
     this.onPrev = onPrev
   }
 
-  _isHidden() {
-    return this.isHidden
+  isHidden() {
+    return this._isHidden
   }
 
   hide() {
     this.buttonPanel.style.display = 'none'
-    this.isHidden === false ? (this.isHidden = !this._isHidden()) : null
+    this._isHidden = true
   }
 
   showLeftArrow() {
@@ -50,7 +48,7 @@ export default class ButtonPanel implements ButtonPanelMethods {
   show() {
     log.debug('ButtonPanel.show()')
     this.buttonPanel.style.display = 'flex'
-    this.isHidden === true ? (this.isHidden = !this._isHidden()) : null
+    this._isHidden = false
   }
 
   mount(element: Element): void {

--- a/src/ButtonPanel.ts
+++ b/src/ButtonPanel.ts
@@ -1,25 +1,34 @@
 /* The ButtonPanel component */
 import './style.css'
 import log from 'loglevel'
+//@ts-expect-error No need for declaration files for images yet
 import leftArrowComponent from './images/left-arrow.svg'
+//@ts-expect-error No need for declaration files for images yet
 import rightArrowComponent from './images/right-arrow.svg'
+import { ButtonPanelMethods } from './types'
 
-export default class ButtonPanel {
+export default class ButtonPanel implements ButtonPanelMethods {
   leftButtonId = 'next-left-arrow'
   rightButtonId = 'next-right-arrow'
-
-  constructor(onNext, onPrev) {
+  buttonPanel: HTMLDivElement
+  leftArrow: HTMLDivElement
+  rightArrow: HTMLDivElement
+  constructor(
+    public onNext: () => void,
+    public onPrev: () => void,
+    public isHidden: boolean = false,
+  ) {
     this.onNext = onNext
     this.onPrev = onPrev
   }
 
-  isHidden() {
-    return this._isHidden
+  _isHidden() {
+    return this.isHidden
   }
 
   hide() {
     this.buttonPanel.style.display = 'none'
-    this._isHidden = true
+    this.isHidden === false ? (this.isHidden = !this._isHidden()) : null
   }
 
   showLeftArrow() {
@@ -41,10 +50,10 @@ export default class ButtonPanel {
   show() {
     log.debug('ButtonPanel.show()')
     this.buttonPanel.style.display = 'flex'
-    this._isHidden = false
+    this.isHidden === true ? (this.isHidden = !this._isHidden()) : null
   }
 
-  mount(element) {
+  mount(element: Element): void {
     // create a div and mount to the element
     this.buttonPanel = document.createElement('div')
     this.leftArrow = document.createElement('div')
@@ -79,8 +88,10 @@ export default class ButtonPanel {
     this.buttonPanel.style.display = 'none'
   }
 
-  clickHandler(e) {
-    const targetId = e.target.closest('.next-button-container').id
+  clickHandler(e: Event) {
+    const targetId = (e.target as HTMLDivElement).closest(
+      'next-button-container',
+    ).id
 
     if (targetId === this.rightButtonId) {
       console.log('next')

--- a/src/ButtonPanel.ts
+++ b/src/ButtonPanel.ts
@@ -51,7 +51,7 @@ export default class ButtonPanel implements ButtonPanelMethods {
     this._isHidden = false
   }
 
-  mount(element: Element): void {
+  mount(element: Element) {
     // create a div and mount to the element
     this.buttonPanel = document.createElement('div')
     this.leftArrow = document.createElement('div')

--- a/src/ButtonPanel.ts
+++ b/src/ButtonPanel.ts
@@ -13,7 +13,7 @@ export default class ButtonPanel implements ButtonPanelMethods {
   buttonPanel: HTMLDivElement
   leftArrow: HTMLDivElement
   rightArrow: HTMLDivElement
-  private _isHidden: Boolean
+  private _isHidden: boolean
 
   constructor(public onNext: () => void, public onPrev: () => void) {
     this.onNext = onNext
@@ -86,7 +86,7 @@ export default class ButtonPanel implements ButtonPanelMethods {
     this.buttonPanel.style.display = 'none'
   }
 
-  clickHandler(e: Event) {
+  clickHandler(e: MouseEvent) {
     const targetId = (e.target as HTMLDivElement).closest(
       'next-button-container',
     ).id

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,5 +13,5 @@ export type ButtonPanelMethods = {
   hideRightArrow: () => void
   show: () => void
   mount: (e: Element) => void
-  clickHandler: (e: Event) => void
+  clickHandler: (e: MouseEvent) => void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,6 @@ export type CoordinatesType = {
 }
 
 export type ButtonPanelMethods = {
-  _isHidden: () => void
   hide: () => void
   showLeftArrow: () => void
   showRightArrow: () => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,3 +4,15 @@ export type CoordinatesType = {
   lat: number
   lng: number
 }
+
+export type ButtonPanelMethods = {
+  _isHidden: () => void
+  hide: () => void
+  showLeftArrow: () => void
+  showRightArrow: () => void
+  hideLeftArrow: () => void
+  hideRightArrow: () => void
+  show: () => void
+  mount: (e: Element) => void
+  clickHandler: (e: Event) => void
+}


### PR DESCRIPTION
Outstanding Issues:

I tried to look at web-map-core's frontend views via ```npm run dev``` but I received 400+ errors from webpack I suppose from the other components and types that don't have any type or type annotations on them at the moment. 