### PR TITLE
177 Fixing 'leaflet_id' in undefined runtime error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .eslintcache
+.idea

--- a/src/Map.js
+++ b/src/Map.js
@@ -406,12 +406,12 @@ export default class Map {
   }
 
   async _unloadTileServer() {
-    if (this.map.hasLayer(this.layerTile)) {
+    if (this.layerTile && this.map.hasLayer(this.layerTile)) {
       this.map.removeLayer(this.layerTile)
     } else {
       log.warn('try to remove nonexisting tile layer')
     }
-    if (this.map.hasLayer(this.layerUtfGrid)) {
+    if (this.layerUtfGrid && this.map.hasLayer(this.layerUtfGrid)) {
       this.map.removeLayer(this.layerUtfGrid)
     } else {
       log.warn('try to remove nonexisting grid layer')
@@ -593,7 +593,7 @@ export default class Map {
       this.layerSelected?.payload,
     )
 
-    if (this.map.hasLayer(this.layerSelected)) {
+    if (this.layerSelected && this.map.hasLayer(this.layerSelected)) {
       this.map.removeLayer(this.layerSelected)
     } else {
       log.warn('try to remove nonexisting layer selected')


### PR DESCRIPTION
Fixes #177 

It seems when we upgraded the leaflet library that leaflet's map method changed from being able to accept an undefined parameter to throwing a runtime error when the parameter is undefined.  

This PR adds an extra check that a layer object exists before passing it to the hasLayer method